### PR TITLE
Honor custom extensions when constructing output paths.

### DIFF
--- a/module/scripts/compile-ffi.scm
+++ b/module/scripts/compile-ffi.scm
@@ -259,7 +259,10 @@ Report bugs to https://github.com/mwette/nyacc/issues.\n"))
    ((assq-ref opts 'output))
    ((assq-ref opts 'output-dir) =>
     (lambda (dir) (string-append dir "/" (basename ffi-file ".ffi") ".scm")))
-   (else (string-append (string-drop-right ffi-file 4) ".scm"))))
+   (else (string-append (string-take ffi-file
+                                     (string-index-right ffi-file
+                                                         #\.))
+                        ".scm"))))
 
 ;; from list of all files and depd, return supplier-for dict
 (define (ensure-ffi-deps file opts)


### PR DESCRIPTION
The term "foreign function interface" is a misnomer for much of my work, which goes "native" with published APIs and inline assembly.  I like to name my input files with `*.nyacc` file extensions, which `compile-ffi` accepts with the command-line option `--any-suffix`.  Unfortunately, it then does not replace the custom extension correctly when constructing names for output files.

Here is an example.  For the input file `errno.nyacc`, the generated file has the name `errno.n.scm`.  That's because the replacement index is fixed at 4 from the right:
```
(sid_s390x-dchroot)lechner@zelenka:~$GUILE_LOAD_PATH=/home/lechner/nyacc/module guild compile-ffi --any-suffix --inc-dir=guile-cdata-linux/include/ guile-cdata-linux/scm/cdata/linux/errno.nyacc [...]
compiling `guile-cdata-linux/scm/cdata/linux/errno.nyacc' ...
... wrote `guile-cdata-linux/scm/cdata/linux/errno.n.scm'
compiling `guile-cdata-linux/scm/cdata/linux/errno.n.scm' ...
... wrote `errno.n.scm.go'
```
This patch instead looks for the right-most period in input file names and cuts them there.  The name `errno.scm` is then correct:
```
(sid_s390x-dchroot)lechner@zelenka:~$GUILE_LOAD_PATH=/home/lechner/nyacc/module guild compile-ffi --any-suffix --inc-dir=guile-cdata-linux/include/ guile-cdata-linux/scm/cdata/linux/errno.nyacc [...]
compiling `guile-cdata-linux/scm/cdata/linux/errno.nyacc' ...
... wrote `guile-cdata-linux/scm/cdata/linux/errno.scm'
compiling `guile-cdata-linux/scm/cdata/linux/errno.scm' ...
... wrote `errno.scm.go'
```